### PR TITLE
Benchmark 2.0.0 - 2026 May QA Sync

### DIFF
--- a/run_audit.sh
+++ b/run_audit.sh
@@ -89,7 +89,7 @@ fi
 # Define os_vendor variable
 # Use /etc/os-release as primary source (works in containers where uname/hostnamectl may fail)
 if [ -f /etc/os-release ]; then
-  os_id="$(grep -w "^ID=" /etc/os-release | cut -d= -f2 | tr -d '"' | awk '{print tolower($0)}')"
+  os_id="$(grep "^ID=" /etc/os-release | cut -d= -f2 | tr -d '"' | awk '{print tolower($0)}')"
   case "$os_id" in
     amzn) os_vendor="AMAZON" ;;
     rhel|ol|oracle|rocky|almalinux|centos) os_vendor="RHEL" ;;
@@ -107,7 +107,21 @@ else
   fi
 fi
 
-os_maj_ver="$(grep -w VERSION_ID= /etc/os-release | awk -F\" '{print $2}' | cut -d '.' -f1)"
+os_maj_ver="$(grep "^VERSION_ID=" /etc/os-release | cut -d= -f2 | tr -d '"' | cut -d '.' -f1)"
+
+# Fallback to BENCHMARK_OS constants if detection produced empty results.
+# This audit is single-OS by design (BENCHMARK_OS hardcoded above); detection
+# is a sanity check, not a load-bearing identifier. Pathological /etc/os-release
+# (missing ID=, missing VERSION_ID=, etc.) must not silently produce wrong paths.
+if [ -z "$os_vendor" ]; then
+  os_vendor="${BENCHMARK_OS//[0-9]/}"
+  echo "WARNING - OS vendor detection produced empty result; falling back to BENCHMARK_OS vendor=${os_vendor}"
+fi
+if [ -z "$os_maj_ver" ]; then
+  os_maj_ver="${BENCHMARK_OS//[A-Za-z]/}"
+  echo "WARNING - OS version detection produced empty result; falling back to BENCHMARK_OS version=${os_maj_ver}"
+fi
+
 audit_content_version=$os_vendor$os_maj_ver-$BENCHMARK-Audit
 audit_content_dir=$AUDIT_CONTENT_LOCATION/$audit_content_version
 audit_vars=vars/${BENCHMARK}.yml


### PR DESCRIPTION
Benchmark 2.0.0 - 2026 May QA Sync
- Drop `grep -w` from ID/VERSION_ID extraction. The `^ID=` and `^VERSION_ID=` anchors already constrain the match; `-w` is redundant and silently fails with some non-GNU grep implementations.
- When detection still produces an empty `os_vendor` or `os_maj_ver`, fall back to the hardcoded `BENCHMARK_OS` constant at the top of the script. This audit is single-OS by design, so the detection is a sanity check rather than a load-bearing identifier.
- Emit a clear WARNING on stdout when the fallback fires.

Fixes the CI failure where targets with a missing or non-standard `ID=` line in /etc/os-release produced `/opt/11-CIS-Audit/goss.yml` instead of `/opt/DEBIAN<N>-CIS-Audit/goss.yml`. Verified end-to-end in Debian 11 containers across three scenarios: clean os-release, no-ID-line os-release, and missing-os-release.

**How has this been tested?:**
Molecule
